### PR TITLE
Python should receive a raw string for sys.path

### DIFF
--- a/plugin/vtd.vim
+++ b/plugin/vtd.vim
@@ -28,4 +28,4 @@ endif
 let s:python_path = maktaba#path#Join([expand('<sfile>:p:h:h'), 'python'])
 let s:libvtd_path = maktaba#path#Join([s:python_path, 'libvtd'])
 execute 'pyfile' maktaba#path#Join([s:python_path, 'sysutil.py']) 
-execute 'python AddToSysPath("' . s:libvtd_path . '")'
+execute 'python AddToSysPath(r"' . s:libvtd_path . '")'


### PR DESCRIPTION
Python is sent a path to find the libvtd module. The call is done by
executing python code as a string directly. However, the string passed
is not escaped, and with Windows paths (containing backslashes) this
means Python converts all escape sequences.

Solved by adding an r before the string literal, making it into a raw
Python string, which does not escape the backslashes.

Fixes #21. 