### PR TITLE
Avoid closing windows when exiting VTD View

### DIFF
--- a/autoload/vtd/view.vim
+++ b/autoload/vtd/view.vim
@@ -285,7 +285,7 @@ function! s:VtdView.switchToViewBuffer()
   if l:vtd_view_window >= 0
     " We prefer to simply go to a window which already has that buffer,
     " if such a window exists.
-    execute l:vtd_view_window . 'wincmd w'
+    call s:GotoWindow(l:vtd_view_window)
   else
     " Otherwise, just open it in the current window.
     execute 'buffer' s:vtd_view_buffer_number
@@ -1096,6 +1096,13 @@ function! s:Warn(message)
   echohl WarningMsg
   echomsg a:message
   echohl none
+endfunction
+
+
+""
+" Switch to the given window number.
+function! s:GotoWindow(win_num)
+  execute a:win_num . 'wincmd w'
 endfunction
 
 

--- a/autoload/vtd/view.vim
+++ b/autoload/vtd/view.vim
@@ -808,8 +808,8 @@ function! vtd#view#Enter(...)
   call s:UpdateSystemContexts()
 
   " Check whether a VTD View object already exists.
-  let l:view_already_existed = empty(s:current_vtd_view)
-  if !l:view_already_existed
+  let l:view_already_existed = !empty(s:current_vtd_view)
+  if l:view_already_existed
     " If the existing view is valid, simply enter it directly, and we're done.
     if !l:specific_type_requested || l:view_type == s:CurrentViewType()
       call s:current_vtd_view.switchToViewBuffer()


### PR DESCRIPTION
The trick turned out to be simple!  Just switch every window away from that buffer, and _then_ `bwipeout`.

(This might make a good contribution for `maktaba#buffers`, if fixed up.  I'd much rather just be calling a library.)